### PR TITLE
Fix wrong namespace for Python 3.3 image

### DIFF
--- a/3.3/s2i/bin/usage
+++ b/3.3/s2i/bin/usage
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 DISTRO=`cat /etc/*-release | grep ^ID= | grep -Po '".*?"' | tr -d '"'`
+NAMESPACE=centos
+[[ $DISTRO =~ rhel* ]] && NAMESPACE=rhscl
 
 cat <<EOF
 This is a S2I python-3.3 ${DISTRO} base image:
@@ -8,7 +10,7 @@ To use it, install S2I: https://github.com/openshift/source-to-image
 
 Sample invocation:
 
-s2i build https://github.com/openshift/s2i-python.git --context-dir=3.3/test/setup-test-app/ openshift/python-33-${DISTRO}7 python-sample-app
+s2i build https://github.com/openshift/s2i-python.git --context-dir=3.3/test/setup-test-app/ ${NAMESPACE}/python-33-${DISTRO}7 python-sample-app
 
 
 You can then run the resulting image via:


### PR DESCRIPTION
Python 3.3 image is currently listed under "openshift" namespace
which is deprecated. The correct namespace is "centos".

Signed-off-by: Vu Dinh <vdinh@redhat.com>